### PR TITLE
new example displaying entry info with kanji and reading

### DIFF
--- a/examples/kanji_info.rs
+++ b/examples/kanji_info.rs
@@ -1,0 +1,39 @@
+/*******************************************************************************
+* SPDX-License-Identifier: Apache-2.0 Refer to the file "LICENSE" for details.
+* example illustrating how to access kanji and reading information for a word
+*******************************************************************************/
+use jmdict::{KanjiElement, ReadingElement};
+
+fn main() {
+    let input = "一日";
+    let count = jmdict::entries()
+        .filter(|e| {
+            let mut result = false;
+            if e.kanji_elements().any(|k| k.text == input) {
+                result = true;
+                println!("--- entry #{} ---", e.number);
+                let kanji_elements: Vec<KanjiElement> = e.kanji_elements().map(|ke| ke).collect();
+                for kanji in &kanji_elements {
+                    println!("kanji element: {}", kanji.text);
+                    println!("   priority: {:?}\n", kanji.priority);
+                }
+
+                let reading_forms: Vec<ReadingElement> = e.reading_elements().map(|item| item).collect();
+                for reading in reading_forms {
+                    println!("reading_form: {}", reading.text);
+                    println!("   priority: {:?}\n", reading.priority);
+
+                    for info in reading.infos() {
+                        println!("info: {:?}", info);
+                    }
+                }
+
+
+                // let sense = e.senses().next().unwrap().text;
+
+            }
+            result
+        })
+        .count();
+    println!("{} entries for {}", count, input);
+}

--- a/examples/kanji_info.rs
+++ b/examples/kanji_info.rs
@@ -2,24 +2,21 @@
 * SPDX-License-Identifier: Apache-2.0 Refer to the file "LICENSE" for details.
 * example illustrating how to access kanji and reading information for a word
 *******************************************************************************/
-use jmdict::{KanjiElement, ReadingElement};
 
 fn main() {
     let input = "一日";
     let count = jmdict::entries()
         .filter(|e| {
-            let mut result = false;
             if e.kanji_elements().any(|k| k.text == input) {
-                result = true;
+                // note two entries have identical Kanji and reading
+                // yet differ in "sense" not shown in this example
                 println!("--- entry #{} ---", e.number);
-                let kanji_elements: Vec<KanjiElement> = e.kanji_elements().map(|ke| ke).collect();
-                for kanji in &kanji_elements {
+                for kanji in e.kanji_elements() {
                     println!("kanji element: {}", kanji.text);
                     println!("   priority: {:?}\n", kanji.priority);
                 }
 
-                let reading_forms: Vec<ReadingElement> = e.reading_elements().map(|item| item).collect();
-                for reading in reading_forms {
+                for reading in e.reading_elements() {
                     println!("reading_form: {}", reading.text);
                     println!("   priority: {:?}\n", reading.priority);
 
@@ -28,11 +25,9 @@ fn main() {
                     }
                 }
 
-
-                // let sense = e.senses().next().unwrap().text;
-
+                return true
             }
-            result
+            false
         })
         .count();
     println!("{} entries for {}", count, input);

--- a/examples/kanji_info.rs
+++ b/examples/kanji_info.rs
@@ -8,8 +8,8 @@ fn main() {
     let count = jmdict::entries()
         .filter(|e| {
             if e.kanji_elements().any(|k| k.text == input) {
-                // note two entries have identical Kanji and reading
-                // yet differ in "sense" not shown in this example
+                // note two entries have identical Kanji  
+                // yet differ in reading
                 println!("--- entry #{} ---", e.number);
                 for kanji in e.kanji_elements() {
                     println!("kanji element: {}", kanji.text);


### PR DESCRIPTION
Cool library!  I'm not a Rust expert, so this might not be the best example code, but I had a hard time figuring out how to generate this kind of info from the reference documentation.  I thought it might be helpful to others if you wanted to merge it.  

Would love feedback and happy to improve this, or, of course, feel free to modify if you are inspired to provide a better example along these lines.  (I'm still trying to wrap my head around what information is available in the dictionary and how it is structured, as well as learning the Rust language!)